### PR TITLE
Update 'pending' tasks, whenever tasks complete.

### DIFF
--- a/black.py
+++ b/black.py
@@ -487,6 +487,7 @@ async def schedule_formatting(
         done, _ = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
         for task in done:
             src = tasks.pop(task)
+            pending = tasks.keys()
             if task.cancelled():
                 cancelled.append(task)
             elif task.exception():


### PR DESCRIPTION
Closes #494

Task completion should also remove the task from `pending`.

Only replicates on some platforms. (eg. Can replicate on Python 3.7+, with either Windows or whatever default Linux distro Travis uses.)